### PR TITLE
Ignore .awcache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 platforms/
 
 # NativeScript Template
+.awcache
 *.js.map
 *.js
 !webpack.config.js


### PR DESCRIPTION
No need to source-control the Awesome TypeScript Loader's build cache (and caching is optional, anyway).

I'll check whether `.awcache` is successfully ignored when building a fresh project with the latest version of my RNS template. Had expected it to be, but there was an earlier version of the template that neglected to do this.